### PR TITLE
Add register vehicle method and tests

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -1,14 +1,73 @@
 class Facility
-  attr_reader :name, :address, :phone, :services
+  attr_reader :name, :address, :phone, :services, :collected_fees, :registered_vehicles
+  attr_accessor :plate_type
 
   def initialize(info)
     @name = info[:name]
     @address = info[:address]
     @phone = info[:phone]
     @services = []
+    @registered_vehicles = []
+    @collected_fees = 0 
   end
 
   def add_service(service)
     @services << service
+  end
+
+  def register_vehicle(vehicle)
+    if !@services.include?('Vehicle Registration')
+      "This facility does not offer that service"
+    else
+      set_registration_date(vehicle)
+      set_plate_type(vehicle)
+      collect_fees(vehicle)
+      add_to_registered_vehicles(vehicle)
+    end
+  end
+
+  def set_registration_date(vehicle)
+    today = Date.today
+    formatted_date = today.strftime("%Y-%d-%m")
+    vehicle.registration_date = formatted_date
+  end
+  
+  def set_plate_type(vehicle)
+    if vehicle.antique?
+      vehicle.plate_type = :antique
+    elsif vehicle.electric_vehicle?
+      vehicle.plate_type = :ev
+    else
+      vehicle.plate_type = :regular
+    end
+  end
+  
+  def collect_fees(vehicle)
+    if vehicle.antique?
+      @collected_fees += 25 
+    elsif vehicle.electric_vehicle?
+      @collected_fees += 200
+    else
+      @collected_fees += 100
+    end
+  end
+
+  def add_to_registered_vehicles(vehicle)
+    registered_vehicles << vehicle
+  end
+
+
+
+  def administer_written_test
+    #registrant with permit and 16 y/o
+  end
+
+  def administer_road_test 
+    #registrant must pass the written test
+    #registrant who qualify earn a license
+  end
+
+  def renew_license 
+    #can only be renewed if registrant has passed road_test and earned a license
   end
 end

--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -6,6 +6,8 @@ class Vehicle
               :make,
               :model,
               :engine
+  attr_accessor :registration_date,
+                :plate_type
 
   def initialize(vehicle_details)
     @vin = vehicle_details[:vin]
@@ -13,6 +15,8 @@ class Vehicle
     @make = vehicle_details[:make]
     @model = vehicle_details[:model]
     @engine = vehicle_details[:engine]
+    @registration_date = nil
+    @plate_type = nil
   end
 
   def antique?
@@ -24,5 +28,6 @@ class Vehicle
   end
 
   def registration_date
+    @registration_date
   end
 end

--- a/spec/dmv_spec.rb
+++ b/spec/dmv_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Dmv do
     @facility_1 = Facility.new({name: 'DMV Tremont Branch', address: '2855 Tremont Place Suite 118 Denver CO 80205', phone: '(720) 865-4600'})
     @facility_2 = Facility.new({name: 'DMV Northeast Branch', address: '4685 Peoria Street Suite 101 Denver CO 80239', phone: '(720) 865-4600'})
     @facility_3 = Facility.new({name: 'DMV Northwest Branch', address: '3698 W. 44th Avenue Denver CO 80211', phone: '(720) 865-4600'})
+    @cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
+    @bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
+    @camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
   end
 
   describe '#initialize' do
@@ -40,6 +43,66 @@ RSpec.describe Dmv do
       @dmv.add_facility(@facility_3)
 
       expect(@dmv.facilities_offering_service('Road Test')).to eq([@facility_2, @facility_3])
+    end
+  end
+
+  describe '#register_vehicle' do
+    it 'will not register if facility does not offer Vehicle Registration service' do 
+      expect(@facility_1.register_vehicle(@cruz)).to eq "This facility does not offer that service"
+    end
+
+    it 'can track registration date' do
+      @facility_1.add_service('Vehicle Registration')
+      expect(@cruz.registration_date).to eq nil 
+
+      @facility_1.register_vehicle(@cruz)
+
+      todays_date = Date.today.strftime("%Y-%d-%m")
+      expect(@cruz.registration_date).to eq todays_date
+    end
+
+    it 'can collect fees' do 
+      @facility_1.add_service('Vehicle Registration')
+      expect(@facility_1.collected_fees).to eq 0 
+      
+      @facility_1.register_vehicle(@cruz)
+      expect(@facility_1.collected_fees).to eq 100
+
+      @facility_1.register_vehicle(@camaro)
+      expect(@facility_1.collected_fees).to eq 125 
+
+      @facility_1.register_vehicle(@bolt)
+      expect(@facility_1.collected_fees).to eq 325
+    end
+    
+    it 'can #set_plate_type upon registration' do
+      @facility_1.add_service('Vehicle Registration')
+
+      expect(@cruz.plate_type).to eq nil
+      @facility_1.register_vehicle(@cruz)
+      expect(@cruz.plate_type).to eq :regular
+      
+      expect(@camaro.plate_type).to eq nil
+      @facility_1.register_vehicle(@camaro)
+      expect(@camaro.plate_type).to eq :antique
+      
+      expect(@bolt.plate_type).to eq nil
+      @facility_1.register_vehicle(@bolt)
+      expect(@bolt.plate_type).to eq :ev
+    end
+    
+    it 'can add vehicle to the list of facility registered cars' do 
+      @facility_1.add_service('Vehicle Registration')
+      expect(@facility_1.registered_vehicles).to eq []
+      
+      @facility_1.register_vehicle(@cruz)
+      expect(@facility_1.registered_vehicles).to eq [@cruz]
+      
+      @facility_1.register_vehicle(@camaro)
+      expect(@facility_1.registered_vehicles).to eq [@cruz, @camaro]
+      
+      @facility_1.register_vehicle(@bolt)
+      expect(@facility_1.registered_vehicles).to eq [@cruz, @camaro, @bolt]
     end
   end
 end


### PR DESCRIPTION
the #register_vehicle is comprised of a conditional to only work if the facility offers the service

it the facility offers the service, it uses helper methods to run all functionality based on vehicle type: 

- set registration date
- set license plate type
- collects the fee
- adds it to the facilities 

