### PR TITLE
add changes to #administer_written_test and sad path testing

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -61,11 +61,13 @@ class Facility
   def administer_written_test(registrant)
     if !@services.include?('Written Test')
       "This facility does not offer that service"
+    elsif registrant.permit? == false 
+      "Registrant does not have a permit"
+    elsif registrant.age < 16 
+      "Registrant is not old enough to take written test"
     else
       if registrant.permit? == true and registrant.age >= 16
-      registrant.license_data[:written] = true
-      else
-        "Unable to take written test"
+        registrant.license_data[:written] = true
       end
     end
   end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -25,7 +25,7 @@ class Facility
       add_to_registered_vehicles(vehicle)
     end
   end
-
+  
   def set_registration_date(vehicle)
     today = Date.today
     formatted_date = today.strftime("%Y-%d-%m")
@@ -51,23 +51,31 @@ class Facility
       @collected_fees += 100
     end
   end
-
+  
   def add_to_registered_vehicles(vehicle)
     registered_vehicles << vehicle
   end
-
-
-
-  def administer_written_test
-    #registrant with permit and 16 y/o
+  
+  
+  
+  def administer_written_test(registrant)
+    if !@services.include?('Written Test')
+      "This facility does not offer that service"
+    else
+      if registrant.permit? == true and registrant.age >= 16
+      registrant.license_data[:written] = true
+      else
+        "Unable to take written test"
+      end
+    end
   end
 
-  def administer_road_test 
-    #registrant must pass the written test
-    #registrant who qualify earn a license
-  end
+  # def administer_road_test 
+  #   #registrant must pass the written test
+  #   #registrant who qualify earn a license
+  # end
 
-  def renew_license 
-    #can only be renewed if registrant has passed road_test and earned a license
-  end
+  # def renew_license 
+  #   #can only be renewed if registrant has passed road_test and earned a license
+  # end
 end

--- a/lib/registrant.rb
+++ b/lib/registrant.rb
@@ -1,0 +1,20 @@
+class Registrant 
+    attr_accessor :license_data
+    attr_reader :name,
+                :age
+
+    def initialize(name, age, permit = false)
+        @name = name 
+        @age = age 
+        @permit = permit
+        @license_data = {
+            :written => false,
+            :license => false,
+            :renewed => false
+        }
+    end
+
+    def permit?
+        @permit == true
+    end
+end

--- a/lib/registrant.rb
+++ b/lib/registrant.rb
@@ -17,4 +17,8 @@ class Registrant
     def permit?
         @permit == true
     end
+
+    def earn_permit
+        @permit = true 
+    end
 end

--- a/spec/dmv_spec.rb
+++ b/spec/dmv_spec.rb
@@ -48,7 +48,11 @@ RSpec.describe Dmv do
 
   describe '#register_vehicle' do
     it 'will not register if facility does not offer Vehicle Registration service' do 
-      expect(@facility_1.register_vehicle(@cruz)).to eq "This facility does not offer that service"
+      expect(@facility_2.registered_vehicles).to eq []
+      expect(@facility_2.services).to eq []
+      expect(@facility_2.register_vehicle(@bolt)).to eq "This facility does not offer that service"
+      expect(@facility_2.registered_vehicles).to eq []
+      expect(@facility_2.collected_fees).to eq 0
     end
 
     it 'can track registration date' do

--- a/spec/registrant_spec.rb
+++ b/spec/registrant_spec.rb
@@ -10,6 +10,20 @@ RSpec.describe Registrant do
         @facility_2 = Facility.new({name: 'DMV Northeast Branch', address: '4685 Peoria Street Suite 101 Denver CO 80239', phone: '(720) 865-4600'})
     end 
 
+    describe 'permits' do 
+        it 'can see if registrant has a #permit?' do 
+            expect(@registrant_1.permit?).to eq true 
+        end
+        
+        it 'can have a registrant #earn_permit' do 
+            expect(@registrant_2.permit?).to eq false 
+            
+            @registrant_2.earn_permit 
+            
+            expect(@registrant_2.permit?).to eq true
+        end
+    end
+
     describe '#written_test' do
         it 'can return #license_data' do 
             expected_hash = {
@@ -18,10 +32,6 @@ RSpec.describe Registrant do
                 :renewed =>false
             }
             expect(@registrant_1.license_data).to eq expected_hash
-        end
-
-        it 'can see if registrant has a #permit?' do 
-            expect(@registrant_1.permit?).to eq true 
         end
 
         it 'will not #administer_written_test is facility does not provied written test service' do
@@ -37,6 +47,36 @@ RSpec.describe Registrant do
                 :renewed => false
             }
             expect(@registrant_1.license_data).to eq expected
+        end
+        
+        it 'will not #administer_written_test if the registrant does not have a permit' do 
+            @facility_1.add_service('Written Test')
+            expect(@facility_1.administer_written_test(@registrant_2)).to eq "Registrant does not have a permit"
+            
+            @registrant_2.earn_permit
+            @facility_1.administer_written_test(@registrant_2)
+            expected = {
+                :written => true,
+                :license => false,
+                :renewed => false
+            }
+            expect(@registrant_2.license_data).to eq expected
+        end
+        
+        it 'will not #administer_written_test if the registrant is not at least 16 years of age' do 
+            @facility_1.add_service('Written Test')
+            expect(@registrant_3.age).to eq 15
+            expect(@registrant_3.permit?).to eq false 
+            expect(@facility_1.administer_written_test(@registrant_3)).to eq "Registrant does not have a permit"
+            @registrant_3.earn_permit
+            
+            expect(@facility_1.administer_written_test(@registrant_3)).to eq "Registrant is not old enough to take written test"
+            expected = {
+                :written => false,
+                :license => false,
+                :renewed => false
+            }
+            expect(@registrant_3.license_data).to eq expected
         end
     end
 end

--- a/spec/registrant_spec.rb
+++ b/spec/registrant_spec.rb
@@ -1,0 +1,42 @@
+require './lib/registrant'
+require './lib/facility'
+
+RSpec.describe Registrant do 
+    before do 
+        @registrant_1 = Registrant.new('Bruce', 18, true )
+        @registrant_2 = Registrant.new('Penny', 16 )
+        @registrant_3 = Registrant.new('Tucker', 15 )
+        @facility_1 = Facility.new({name: 'DMV Tremont Branch', address: '2855 Tremont Place Suite 118 Denver CO 80205', phone: '(720) 865-4600'})
+        @facility_2 = Facility.new({name: 'DMV Northeast Branch', address: '4685 Peoria Street Suite 101 Denver CO 80239', phone: '(720) 865-4600'})
+    end 
+
+    describe '#written_test' do
+        it 'can return #license_data' do 
+            expected_hash = {
+                :written => false,
+                :license => false,
+                :renewed =>false
+            }
+            expect(@registrant_1.license_data).to eq expected_hash
+        end
+
+        it 'can see if registrant has a #permit?' do 
+            expect(@registrant_1.permit?).to eq true 
+        end
+
+        it 'will not #administer_written_test is facility does not provied written test service' do
+            expect(@facility_1.administer_written_test(@registrant_1)).to eq "This facility does not offer that service"
+        end
+        
+        it 'will change written status to true if facility offers the service, registrant is of age and has permit' do 
+            @facility_1.add_service('Written Test')
+            @facility_1.administer_written_test(@registrant_1)
+            expected = {
+                :written => true,
+                :license => false,
+                :renewed => false
+            }
+            expect(@registrant_1.license_data).to eq expected
+        end
+    end
+end


### PR DESCRIPTION
- Added more conditionals to #administer_written_test method to check for permit and for age
- Created tests in facility_spec file to test sad path if registrant does not have a permit or atleast 16y/o
- returns a string of what the error is