### PR TITLE
Add changes for road test method

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -71,11 +71,18 @@ class Facility
       end
     end
   end
-
-  # def administer_road_test 
-  #   #registrant must pass the written test
-  #   #registrant who qualify earn a license
-  # end
+  
+  def administer_road_test(registrant)
+    if !@services.include?('Road Test')
+      "This facility does not offer that service"
+    else
+      if registrant.license_data[:written] == false 
+        "Must pass written test first"
+      else
+        registrant.license_data[:license] = true
+      end
+    end
+  end
 
   # def renew_license 
   #   #can only be renewed if registrant has passed road_test and earned a license

--- a/spec/registrant_spec.rb
+++ b/spec/registrant_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Registrant do
     end
 
     describe 'written test' do
-        it 'will change written status to true if facility offers the service, registrant is of age and has permit' do 
+        it '#administer_written_test will change written status to true if facility offers the service, registrant is of age and has permit' do 
             @facility_1.add_service('Written Test')
             @facility_1.administer_written_test(@registrant_1)
             expected = {
@@ -85,6 +85,36 @@ RSpec.describe Registrant do
     end
 
     describe 'road test' do
+        it '#administer_road_test will change license data to true if registrant has passed written test' do 
+            @facility_1.add_service('Written Test')
+            @facility_1.add_service('Road Test')
+            @facility_1.administer_written_test(@registrant_1)
+            @facility_1.administer_road_test(@registrant_1)
+            expected = {
+                :written => true,
+                :license => true,
+                :renewed => false
+            }
+            
+            expect(@registrant_1.license_data).to eq expected 
+        end
         
+        context 'sad path' do
+            it 'will not #administer_road_test if facility does not offer the road test service' do 
+                expect(@facility_1.administer_road_test(@registrant_1)).to eq "This facility does not offer that service"
+            end
+        
+            it 'will not #administer_road_test if registrant did not yet pass the written test' do 
+                @facility_1.add_service('Road Test')
+                expected = {
+                    :written => false,
+                    :license => false,
+                    :renewed => false
+                }
+                
+                expect(@facility_1.administer_road_test(@registrant_1)).to eq "Must pass written test first"
+                expect(@registrant_1.license_data).to eq expected 
+            end 
+        end
     end
 end


### PR DESCRIPTION
Added #administer_road_test method and tests for spec file: 

- facility must have "Road Test" service 
- registrant must have passed the written test prior 
- if conditions are met, #administer_road_test will change the license_data license status to true 
