### PR TITLE
Add changes for renew drivers license method and tests

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -83,8 +83,14 @@ class Facility
       end
     end
   end
-
-  # def renew_license 
-  #   #can only be renewed if registrant has passed road_test and earned a license
-  # end
+  
+  def renew_drivers_license(registrant) 
+    if !@services.include?('Renew License')
+      "This facility does not offer that service"
+    elsif registrant.license_data[:license] == false 
+      "Registrant does not have a drivers license"
+    else 
+      registrant.license_data[:renewed] = true
+    end
+  end
 end

--- a/spec/registrant_spec.rb
+++ b/spec/registrant_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Registrant do
             it 'will not #administer_road_test if facility does not offer the road test service' do 
                 expect(@facility_1.administer_road_test(@registrant_1)).to eq "This facility does not offer that service"
             end
-        
+            
             it 'will not #administer_road_test if registrant did not yet pass the written test' do 
                 @facility_1.add_service('Road Test')
                 expected = {
@@ -115,6 +115,35 @@ RSpec.describe Registrant do
                 expect(@facility_1.administer_road_test(@registrant_1)).to eq "Must pass written test first"
                 expect(@registrant_1.license_data).to eq expected 
             end 
+        end
+    end
+
+    describe 'renew license' do 
+        it 'can #renew_drivers_license for a given registrant' do 
+            @facility_1.add_service('Written Test')
+            @facility_1.add_service('Road Test')
+            @facility_1.add_service('Renew License')
+            @facility_1.administer_written_test(@registrant_1)
+            @facility_1.administer_road_test(@registrant_1)
+            @facility_1.renew_drivers_license(@registrant_1)
+            expected = {
+                :written => true,
+                :license => true,
+                :renewed => true
+            }
+            
+            expect(@registrant_1.license_data).to eq expected
+        end
+
+        context 'sad path' do 
+            it 'will not #renew_drivers_license if facility does not offer the renew license service' do
+                expect(@facility_1.renew_drivers_license(@registrant_1)).to eq "This facility does not offer that service"
+            end
+
+            it 'will not #renew_drivers_license if registrant does have their license' do 
+                @facility_1.add_service('Renew License')
+                expect(@facility_1.renew_drivers_license(@registrant_1)).to eq "Registrant does not have a drivers license"
+            end
         end
     end
 end


### PR DESCRIPTION
Added #renew_drivers_license method and tests 

- method will change registrant license_data renew status to true if they have a license and the facility offers the service 
- it will not change status if the facility does not offer the service 
- it will not change status if the registrant does not have a drivers license 